### PR TITLE
Corrected SEO

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -12,6 +12,8 @@ sitemap:
   lastmod: 2025-08-26
 ---
 
+# Contact Us
+
 Have a question, or want to book a consultation? Feel free to reach us at any time!
 
 {% include webform.html %}

--- a/services.md
+++ b/services.md
@@ -26,4 +26,3 @@ Whatever your business may need, we have you covered. See how both managed devic
   </video>
 </div>
 
-*Comprehensive managed Apple services for Alberta businesses - from startup to enterprise scale.*


### PR DESCRIPTION
Contact us page did not have the '# Contact Us' title in the body, so it was defaulting to the hidden SEO Title.