### PR TITLE
Bring calculator pages into the site layout

### DIFF
--- a/calculators/mac_vs_pc_calculator.html
+++ b/calculators/mac_vs_pc_calculator.html
@@ -1,308 +1,28 @@
 ---
-layout: none
+layout: default
 permalink: /calculators/mac_vs_pc_calculator.html
+seo_title: "Mac vs PC TCO Calculator — Total Cost of Ownership Tool | RIPEDA"
+seo_description: "Free Mac vs PC total cost of ownership (TCO) calculator. Compare purchase price, lifespan, support costs, and resale value over a full business cycle."
+bodyClass: calculator-page
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mac vs PC TCO Calculator — Total Cost of Ownership Tool | RIPEDA</title>
-    <meta name="description" content="Free Mac vs PC total cost of ownership (TCO) calculator. Compare purchase price, lifespan, support costs, and resale value over a full business cycle.">
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+{%- comment -%}
+Converted 2026-07-31 from `layout: none` to `layout: default`.
 
-        body {
-            font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
-            background: #f8f9fa;
-            min-height: 100vh;
-            padding: 20px;
-        }
+Why: as a standalone bare document this page had no canonical tag, no Cloudflare
+Analytics beacon, no CSP, no Open Graph tags and no site navigation — despite being
+the highest-impression page on the domain (1,295 impressions over the three months
+to 2026-07-29, 44% of the site total). See Planning/SEO_BASELINE_pre-relaunch.md.
 
-        .calculator-container {
-            max-width: 1000px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-            overflow: hidden;
-        }
+The original CSS used a global `*` reset plus bare `body`, `label` and `input`
+rules, and a `.header` class that collides with the site header. Every selector is
+therefore scoped under `.calc-page`. Do not remove that wrapper.
 
-        .header {
-            background: white;
-            color: #2f2f41;
-            padding: 40px;
-            text-align: center;
-            border-bottom: 1px solid #ddd;
-        }
+The permalink must not change: this URL carries all the accumulated search equity.
+{%- endcomment -%}
 
-        .header h1 {
-            font-size: 2.8em;
-            margin-bottom: 15px;
-            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-        }
-
-        .header p {
-            font-size: 1.2em;
-            opacity: 0.9;
-            margin-bottom: 10px;
-        }
-
-        .subtitle {
-            font-size: 1em;
-            opacity: 0.8;
-            font-weight: 300;
-        }
-
-        .form-container {
-            padding: 40px;
-        }
-
-        .form-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 30px;
-            margin-bottom: 30px;
-        }
-
-        .form-group {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .form-group.full-width {
-            grid-column: 1 / -1;
-        }
-
-        label {
-            font-weight: 600;
-            color: #333;
-            margin-bottom: 8px;
-            font-size: 1.1em;
-        }
-
-        input, select {
-            padding: 15px;
-            border: 1px solid #ddd;
-            border-radius: 12px;
-            font-size: 1.1em;
-            transition: all 0.3s ease;
-            background-color: white;
-        }
-
-        input:focus, select:focus {
-            outline: none;
-            border-color: #4a7c95;
-            background-color: white;
-            box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
-        }
-
-        .calculate-btn {
-            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
-            color: white;
-            border: none;
-            padding: 20px 50px;
-            font-size: 1.3em;
-            font-weight: 600;
-            border-radius: 15px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            box-shadow: 0 6px 25px rgba(74, 124, 149, 0.3);
-        }
-
-        .calculate-btn:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 10px 35px rgba(74, 124, 149, 0.4);
-        }
-
-        .results-container {
-            margin-top: 30px;
-            display: none;
-        }
-
-        .savings-summary {
-            background: linear-gradient(135deg, #4a7c95, #4282ae);
-            color: white;
-            padding: 40px;
-            border-radius: 20px;
-            text-align: center;
-            margin-bottom: 30px;
-            box-shadow: 0 10px 30px rgba(74, 124, 149, 0.3);
-        }
-
-        .savings-amount {
-            font-size: 3.5em;
-            font-weight: bold;
-            margin-bottom: 10px;
-            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-        }
-
-        .savings-subtitle {
-            font-size: 1.3em;
-            opacity: 0.9;
-            margin-bottom: 5px;
-        }
-
-        .savings-per-device {
-            font-size: 1.1em;
-            opacity: 0.8;
-        }
-
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 25px;
-            margin-bottom: 30px;
-        }
-
-        .cost-breakdown {
-            background: white;
-            padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-        }
-
-        .cost-breakdown.mac {
-            border-left: 3px solid #4a7c95;
-        }
-
-        .cost-breakdown.pc {
-            border-left: 3px solid #6b9ab8;
-        }
-
-        .cost-breakdown h3 {
-            font-size: 1.5em;
-            margin-bottom: 20px;
-            color: #333;
-        }
-
-        .cost-item {
-            display: flex;
-            justify-content: space-between;
-            padding: 10px 0;
-            border-bottom: 1px solid #f0f0f0;
-        }
-
-        .cost-item:last-child {
-            border-bottom: none;
-            font-weight: bold;
-            font-size: 1.1em;
-            color: #333;
-        }
-
-        .break-even {
-            background: linear-gradient(135deg, #6b9ab8, #4a7c95);
-            color: white;
-            padding: 25px;
-            border-radius: 15px;
-            text-align: center;
-            margin-bottom: 30px;
-        }
-
-        .break-even h3 {
-            font-size: 1.5em;
-            margin-bottom: 10px;
-        }
-
-        .selling-points {
-            background: #f8f9fa;
-            padding: 40px;
-            border-radius: 15px;
-            margin-top: 30px;
-        }
-
-        .selling-points h3 {
-            color: #333;
-            font-size: 1.8em;
-            margin-bottom: 25px;
-            text-align: center;
-        }
-
-        .points-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 20px;
-        }
-
-        .point-item {
-            display: flex;
-            align-items: flex-start;
-            padding: 20px;
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 3px 15px rgba(0, 0, 0, 0.05);
-            transition: transform 0.2s ease;
-            border-left: 3px solid #4a7c95;
-        }
-
-        .point-item:hover {
-            transform: translateY(-2px);
-        }
-
-        .point-icon {
-            font-size: 1.5em;
-            margin-right: 15px;
-            color: #4a7c95;
-        }
-
-        .point-text {
-            flex: 1;
-        }
-
-        .point-text strong {
-            color: #333;
-            display: block;
-            margin-bottom: 5px;
-        }
-
-        .point-text span {
-            color: #666;
-            font-size: 0.95em;
-        }
-
-        .cost-examples {
-            margin-top: 5px;
-            font-size: 0.9em;
-            color: #666;
-            font-style: italic;
-        }
-
-        .ripeda-highlight {
-            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
-            color: white;
-            padding: 30px;
-            border-radius: 15px;
-            margin-top: 30px;
-            text-align: center;
-        }
-
-        .ripeda-highlight h3 {
-            color: white;
-            margin-bottom: 15px;
-        }
-
-        @media (max-width: 768px) {
-            .form-grid, .comparison-grid, .points-grid {
-                grid-template-columns: 1fr;
-            }
-            
-            .header h1 {
-                font-size: 2.2em;
-            }
-            
-            .savings-amount {
-                font-size: 2.5em;
-            }
-        }
-    </style>
-</head>
-<body>
-    <div class="calculator-container">
+<div class="calc-page">
+<div class="calculator-container">
         <div class="header">
             <h1>Mac vs PC TCO Calculator</h1>
             <p>Calculate the true cost savings of switching to Mac</p>
@@ -518,8 +238,260 @@ permalink: /calculators/mac_vs_pc_calculator.html
             </div>
         </div>
     </div>
+</div>
 
-    <script>
+<style>
+.calc-page * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+.calc-page {
+            font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
+            background: #f8f9fa;
+            min-height: 100vh;
+            padding: 20px;
+        }
+.calc-page .calculator-container {
+            max-width: 1000px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+.calc-page .header {
+            background: white;
+            color: #2f2f41;
+            padding: 40px;
+            text-align: center;
+            border-bottom: 1px solid #ddd;
+        }
+.calc-page .header h1 {
+            font-size: 2.8em;
+            margin-bottom: 15px;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        }
+.calc-page .header p {
+            font-size: 1.2em;
+            opacity: 0.9;
+            margin-bottom: 10px;
+        }
+.calc-page .subtitle {
+            font-size: 1em;
+            opacity: 0.8;
+            font-weight: 300;
+        }
+.calc-page .form-container {
+            padding: 40px;
+        }
+.calc-page .form-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+            margin-bottom: 30px;
+        }
+.calc-page .form-group {
+            display: flex;
+            flex-direction: column;
+        }
+.calc-page .form-group.full-width {
+            grid-column: 1 / -1;
+        }
+.calc-page label {
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 8px;
+            font-size: 1.1em;
+        }
+.calc-page input, .calc-page select {
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 12px;
+            font-size: 1.1em;
+            transition: all 0.3s ease;
+            background-color: white;
+        }
+.calc-page input:focus, .calc-page select:focus {
+            outline: none;
+            border-color: #4a7c95;
+            background-color: white;
+            box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
+        }
+.calc-page .calculate-btn {
+            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
+            color: white;
+            border: none;
+            padding: 20px 50px;
+            font-size: 1.3em;
+            font-weight: 600;
+            border-radius: 15px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            box-shadow: 0 6px 25px rgba(74, 124, 149, 0.3);
+        }
+.calc-page .calculate-btn:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 10px 35px rgba(74, 124, 149, 0.4);
+        }
+.calc-page .results-container {
+            margin-top: 30px;
+            display: none;
+        }
+.calc-page .savings-summary {
+            background: linear-gradient(135deg, #4a7c95, #4282ae);
+            color: white;
+            padding: 40px;
+            border-radius: 20px;
+            text-align: center;
+            margin-bottom: 30px;
+            box-shadow: 0 10px 30px rgba(74, 124, 149, 0.3);
+        }
+.calc-page .savings-amount {
+            font-size: 3.5em;
+            font-weight: bold;
+            margin-bottom: 10px;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        }
+.calc-page .savings-subtitle {
+            font-size: 1.3em;
+            opacity: 0.9;
+            margin-bottom: 5px;
+        }
+.calc-page .savings-per-device {
+            font-size: 1.1em;
+            opacity: 0.8;
+        }
+.calc-page .comparison-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 25px;
+            margin-bottom: 30px;
+        }
+.calc-page .cost-breakdown {
+            background: white;
+            padding: 30px;
+            border-radius: 15px;
+            box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+        }
+.calc-page .cost-breakdown.mac {
+            border-left: 3px solid #4a7c95;
+        }
+.calc-page .cost-breakdown.pc {
+            border-left: 3px solid #6b9ab8;
+        }
+.calc-page .cost-breakdown h3 {
+            font-size: 1.5em;
+            margin-bottom: 20px;
+            color: #333;
+        }
+.calc-page .cost-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 10px 0;
+            border-bottom: 1px solid #f0f0f0;
+        }
+.calc-page .cost-item:last-child {
+            border-bottom: none;
+            font-weight: bold;
+            font-size: 1.1em;
+            color: #333;
+        }
+.calc-page .break-even {
+            background: linear-gradient(135deg, #6b9ab8, #4a7c95);
+            color: white;
+            padding: 25px;
+            border-radius: 15px;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+.calc-page .break-even h3 {
+            font-size: 1.5em;
+            margin-bottom: 10px;
+        }
+.calc-page .selling-points {
+            background: #f8f9fa;
+            padding: 40px;
+            border-radius: 15px;
+            margin-top: 30px;
+        }
+.calc-page .selling-points h3 {
+            color: #333;
+            font-size: 1.8em;
+            margin-bottom: 25px;
+            text-align: center;
+        }
+.calc-page .points-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+.calc-page .point-item {
+            display: flex;
+            align-items: flex-start;
+            padding: 20px;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 3px 15px rgba(0, 0, 0, 0.05);
+            transition: transform 0.2s ease;
+            border-left: 3px solid #4a7c95;
+        }
+.calc-page .point-item:hover {
+            transform: translateY(-2px);
+        }
+.calc-page .point-icon {
+            font-size: 1.5em;
+            margin-right: 15px;
+            color: #4a7c95;
+        }
+.calc-page .point-text {
+            flex: 1;
+        }
+.calc-page .point-text strong {
+            color: #333;
+            display: block;
+            margin-bottom: 5px;
+        }
+.calc-page .point-text span {
+            color: #666;
+            font-size: 0.95em;
+        }
+.calc-page .cost-examples {
+            margin-top: 5px;
+            font-size: 0.9em;
+            color: #666;
+            font-style: italic;
+        }
+.calc-page .ripeda-highlight {
+            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
+            color: white;
+            padding: 30px;
+            border-radius: 15px;
+            margin-top: 30px;
+            text-align: center;
+        }
+.calc-page .ripeda-highlight h3 {
+            color: white;
+            margin-bottom: 15px;
+        }
+@media (max-width: 768px) {
+.calc-page .form-grid, .calc-page .comparison-grid, .calc-page .points-grid {
+                grid-template-columns: 1fr;
+            }
+.calc-page .header h1 {
+                font-size: 2.2em;
+            }
+.calc-page .savings-amount {
+                font-size: 2.5em;
+            }
+}
+
+/* Layout integration overrides (added during conversion) */
+.calc-page { min-height: 0; padding: 40px 20px; }
+</style>
+
+<script>
+
         // Canadian pricing data (Apple Store CA, 2026)
         const macPricing = {
             macBookAir: 1399,      // CAD - 13-inch MacBook Air, base
@@ -676,6 +648,5 @@ permalink: /calculators/mac_vs_pc_calculator.html
                 }
             });
         });
-    </script>
-</body>
-</html>
+    
+</script>

--- a/calculators/msp_cost_calculator.html
+++ b/calculators/msp_cost_calculator.html
@@ -1,193 +1,28 @@
 ---
-layout: none
+layout: default
 permalink: /calculators/msp_cost_calculator.html
+seo_title: "IT Downtime Cost Calculator — What Downtime Costs Your Business | RIPEDA"
+seo_description: "Free IT downtime cost calculator. Estimate what an hour of downtime costs your business and weigh it against managed IT service pricing."
+bodyClass: calculator-page
 ---
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>IT Downtime Cost Calculator — What Downtime Costs Your Business | RIPEDA</title>
-    <meta name="description" content="Free IT downtime cost calculator. Estimate what an hour of downtime costs your business and weigh it against managed IT service pricing.">
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
 
-        body {
-            font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
-            background: #f8f9fa;
-            min-height: 100vh;
-            padding: 20px;
-        }
+{%- comment -%}
+Converted 2026-07-31 from `layout: none` to `layout: default`.
 
-        .calculator-container {
-            max-width: 800px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-            overflow: hidden;
-        }
+Why: as a standalone bare document this page had no canonical tag, no Cloudflare
+Analytics beacon, no CSP, no Open Graph tags and no site navigation — despite being
+the highest-impression page on the domain (1,295 impressions over the three months
+to 2026-07-29, 44% of the site total). See Planning/SEO_BASELINE_pre-relaunch.md.
 
-        .header {
-            background: white;
-            color: #2f2f41;
-            padding: 30px;
-            text-align: center;
-            border-bottom: 1px solid #ddd;
-        }
+The original CSS used a global `*` reset plus bare `body`, `label` and `input`
+rules, and a `.header` class that collides with the site header. Every selector is
+therefore scoped under `.calc-page`. Do not remove that wrapper.
 
-        .header h1 {
-            font-size: 2.5em;
-            margin-bottom: 10px;
-            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-        }
+The permalink must not change: this URL carries all the accumulated search equity.
+{%- endcomment -%}
 
-        .header p {
-            font-size: 1.1em;
-            opacity: 0.9;
-        }
-
-        .form-container {
-            padding: 40px;
-        }
-
-        .form-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 30px;
-            margin-bottom: 30px;
-        }
-
-        .form-group {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .form-group.full-width {
-            grid-column: 1 / -1;
-        }
-
-        label {
-            font-weight: 600;
-            color: #333;
-            margin-bottom: 8px;
-            font-size: 1.1em;
-        }
-
-        input, select {
-            padding: 15px;
-            border: 1px solid #ddd;
-            border-radius: 10px;
-            font-size: 1.1em;
-            transition: all 0.3s ease;
-            background-color: white;
-        }
-
-        input:focus, select:focus {
-            outline: none;
-            border-color: #4a7c95;
-            background-color: white;
-            box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
-        }
-
-        .duration-container {
-            display: flex;
-            gap: 15px;
-            align-items: end;
-        }
-
-        .duration-container .form-group {
-            flex: 1;
-        }
-
-        .calculate-btn {
-            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
-            color: white;
-            border: none;
-            padding: 18px 40px;
-            font-size: 1.2em;
-            font-weight: 600;
-            border-radius: 12px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 20px rgba(74, 124, 149, 0.3);
-        }
-
-        .calculate-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 30px rgba(74, 124, 149, 0.4);
-        }
-
-        .result-container {
-            margin-top: 30px;
-            padding: 30px;
-            background: linear-gradient(135deg, #4a7c95, #4282ae);
-            border-radius: 15px;
-            color: white;
-            text-align: center;
-            display: none;
-        }
-
-        .result-amount {
-            font-size: 3em;
-            font-weight: bold;
-            margin-bottom: 10px;
-            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-        }
-
-        .result-breakdown {
-            background: rgba(255, 255, 255, 0.1);
-            padding: 20px;
-            border-radius: 10px;
-            margin-top: 20px;
-            text-align: left;
-        }
-
-        .breakdown-item {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: 8px;
-            padding: 5px 0;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
-        .msp-cta {
-            background: linear-gradient(135deg, #6b9ab8, #4a7c95);
-            padding: 25px;
-            margin-top: 20px;
-            border-radius: 12px;
-            text-align: center;
-            color: white;
-        }
-
-        .msp-cta h3 {
-            color: white;
-            margin-bottom: 10px;
-        }
-
-        @media (max-width: 768px) {
-            .form-grid {
-                grid-template-columns: 1fr;
-                gap: 20px;
-            }
-            
-            .duration-container {
-                flex-direction: column;
-                align-items: stretch;
-            }
-            
-            .header h1 {
-                font-size: 2em;
-            }
-        }
-    </style>
-</head>
-<body>
-    <div class="calculator-container">
+<div class="calc-page">
+<div class="calculator-container">
         <div class="header">
             <h1>IT Downtime Cost Calculator</h1>
             <p>Calculate the true cost of IT outages for Canadian businesses</p>
@@ -276,8 +111,165 @@ permalink: /calculators/msp_cost_calculator.html
             </div>
         </div>
     </div>
+</div>
 
-    <script>
+<style>
+.calc-page * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+.calc-page {
+            font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
+            background: #f8f9fa;
+            min-height: 100vh;
+            padding: 20px;
+        }
+.calc-page .calculator-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+.calc-page .header {
+            background: white;
+            color: #2f2f41;
+            padding: 30px;
+            text-align: center;
+            border-bottom: 1px solid #ddd;
+        }
+.calc-page .header h1 {
+            font-size: 2.5em;
+            margin-bottom: 10px;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        }
+.calc-page .header p {
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
+.calc-page .form-container {
+            padding: 40px;
+        }
+.calc-page .form-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+            margin-bottom: 30px;
+        }
+.calc-page .form-group {
+            display: flex;
+            flex-direction: column;
+        }
+.calc-page .form-group.full-width {
+            grid-column: 1 / -1;
+        }
+.calc-page label {
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 8px;
+            font-size: 1.1em;
+        }
+.calc-page input, .calc-page select {
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+            font-size: 1.1em;
+            transition: all 0.3s ease;
+            background-color: white;
+        }
+.calc-page input:focus, .calc-page select:focus {
+            outline: none;
+            border-color: #4a7c95;
+            background-color: white;
+            box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
+        }
+.calc-page .duration-container {
+            display: flex;
+            gap: 15px;
+            align-items: end;
+        }
+.calc-page .duration-container .form-group {
+            flex: 1;
+        }
+.calc-page .calculate-btn {
+            background: linear-gradient(135deg, #4a7c95, #6b9ab8);
+            color: white;
+            border: none;
+            padding: 18px 40px;
+            font-size: 1.2em;
+            font-weight: 600;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            box-shadow: 0 4px 20px rgba(74, 124, 149, 0.3);
+        }
+.calc-page .calculate-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 30px rgba(74, 124, 149, 0.4);
+        }
+.calc-page .result-container {
+            margin-top: 30px;
+            padding: 30px;
+            background: linear-gradient(135deg, #4a7c95, #4282ae);
+            border-radius: 15px;
+            color: white;
+            text-align: center;
+            display: none;
+        }
+.calc-page .result-amount {
+            font-size: 3em;
+            font-weight: bold;
+            margin-bottom: 10px;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        }
+.calc-page .result-breakdown {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 20px;
+            border-radius: 10px;
+            margin-top: 20px;
+            text-align: left;
+        }
+.calc-page .breakdown-item {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            padding: 5px 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+        }
+.calc-page .msp-cta {
+            background: linear-gradient(135deg, #6b9ab8, #4a7c95);
+            padding: 25px;
+            margin-top: 20px;
+            border-radius: 12px;
+            text-align: center;
+            color: white;
+        }
+.calc-page .msp-cta h3 {
+            color: white;
+            margin-bottom: 10px;
+        }
+@media (max-width: 768px) {
+.calc-page .form-grid {
+                grid-template-columns: 1fr;
+                gap: 20px;
+            }
+.calc-page .duration-container {
+                flex-direction: column;
+                align-items: stretch;
+            }
+.calc-page .header h1 {
+                font-size: 2em;
+            }
+}
+
+/* Layout integration overrides (added during conversion) */
+.calc-page { min-height: 0; padding: 40px 20px; }
+</style>
+
+<script>
+
         // Canadian industry wage data and multipliers
         const industryData = {
             professional: { hourlyRate: 40, name: "Professional Services" },
@@ -374,6 +366,5 @@ permalink: /calculators/msp_cost_calculator.html
                 });
             });
         });
-    </script>
-</body>
-</html>
+    
+</script>


### PR DESCRIPTION
Both calculator pages used `layout: none`, making them standalone bare HTML documents that bypassed _layouts/default.html entirely. They were therefore missing everything the layout provides: canonical tag, Cloudflare Analytics beacon, CSP, Open Graph tags, and site navigation.

That mattered because mac_vs_pc_calculator.html is the highest-impression page on the domain: 1,295 impressions over the three months to 2026-07-29, which is 44% of the site's total, more than the homepage, /services/ and /repairs/ combined. It was converting at 0.5% and reporting no analytics at all.

Changes to both calculators:
- layout: none -> layout: default
- Title and meta description moved into front matter as seo_title and seo_description, preserving the existing hand-written copy verbatim. These are better than anything generated, so they were kept rather than replaced.
- Markup wrapped in <div class="calc-page">
- Every CSS selector scoped under .calc-page. This is required, not cosmetic: the original CSS carried a global `*` reset, bare `body`, `label` and `input, select` rules, and a `.header` class that collides with the site header. Scoping was applied to all 44 selectors in the Mac calculator and all 25 in the downtime calculator, including inside the media queries.
- Added an override to neutralise the original `min-height: 100vh` from the old standalone `body` rule, which would otherwise force a full-viewport block inside the page and push the footer down.
- Permalinks unchanged. /calculators/mac_vs_pc_calculator.html carries all the accumulated search equity and must not move.

Effects: both pages now emit a canonical tag, report to Cloudflare Analytics, inherit the CSP, produce proper social previews, and give a visitor arriving from search an actual route into the site instead of a dead end.

NOT DONE, deliberately - the modal/iframe machinery is left untouched:
- assets/js/calculators.js, _includes/calculators/modal-*.html and the copies inside _includes/bottom-content-section.html and resources.html all still ship. `openModal` is currently defined three times, and modal markup is emitted twice on the homepage and twice on /resources/ (duplicate element IDs, invalid HTML).
- No page actually triggers a modal. The only onclick handlers live in _includes/calculator-sidebar.html, which is included nowhere. Both the homepage and /resources/ link to the calculator pages directly instead.
- Note that this conversion makes the iframe approach unusable anyway: framing these pages would now load the entire site inside the modal. If the modal path is ever wanted again, it needs a bare variant.
- Cleaning that up is a separate change and wants its own testing.

NOT BUILT LOCALLY - no Ruby toolchain available in this environment. Run `bundle exec jekyll serve` and visually check both pages before merging. The CSS scoping is the part most likely to need adjustment: verify the calculator still looks right inside the site chrome, and that the site header, footer and nav are unaffected on those two pages.