### PR TITLE
Fix calculator namespace collision: calc- -> rpcalc-

### DIFF
--- a/calculators/mac_vs_pc_calculator.html
+++ b/calculators/mac_vs_pc_calculator.html
@@ -16,27 +16,32 @@ to 2026-07-29, 44% of the site total). See Planning/SEO_BASELINE_pre-relaunch.md
 
 The original CSS used a global `*` reset plus bare `body`, `label` and `input`
 rules, and a `.header` class that collides with the site header. Every selector is
-therefore scoped under `.calc-page`. Do not remove that wrapper.
+therefore scoped under `.rpcalc-page`, and every calculator class carries an
+`rpcalc-` prefix. Do not remove the wrapper, and do not shorten the prefix to
+`calc-`: the site already defines .calc-header, .calc-title, .calc-icon,
+.calc-button and .calc-description in _sass/_calculators.scss for the
+calculator sidebar component. `rpcalc-` was verified against all 655 class
+names defined across _sass/ and assets/css/ and collides with none of them.
 
 The permalink must not change: this URL carries all the accumulated search equity.
 {%- endcomment -%}
 
-<div class="calc-page">
-<div class="calc-calculator-container">
-        <div class="calc-header">
+<div class="rpcalc-page">
+<div class="rpcalc-calculator-container">
+        <div class="rpcalc-header">
             <h1>Mac vs PC TCO Calculator</h1>
             <p>Calculate the true cost savings of switching to Mac</p>
-            <div class="calc-subtitle">Based on Forrester Research and IBM's enterprise deployment data</div>
+            <div class="rpcalc-subtitle">Based on Forrester Research and IBM's enterprise deployment data</div>
         </div>
 
-        <div class="calc-form-container">
-            <div class="calc-form-grid">
-                <div class="calc-form-group">
+        <div class="rpcalc-form-container">
+            <div class="rpcalc-form-grid">
+                <div class="rpcalc-form-group">
                     <label for="workstations">Number of Workstations</label>
                     <input type="number" id="workstations" min="1" max="10000" value="50" required>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="businessType">Business Type</label>
                     <select id="businessType" required>
                         <option value="">Select business type</option>
@@ -46,57 +51,57 @@ The permalink must not change: this URL carries all the accumulated search equit
                     </select>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="currentPCCost">Current PC Cost per Unit (CAD)</label>
                     <input type="number" id="currentPCCost" min="500" max="5000" value="1400" required>
-                    <div class="calc-cost-examples">
+                    <div class="rpcalc-cost-examples">
                         <small>Examples: Entry business laptop (~$1,400) • High-performance workstation (~$2,800). Memory and SSD shortages pushed PC prices up through 2026.</small>
                     </div>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="itSupportCost">Annual IT Support Cost per User (CAD)</label>
                     <input type="number" id="itSupportCost" min="100" max="2000" value="600" required>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="windowsLicense">Windows License Cost per User (CAD)</label>
                     <input type="number" id="windowsLicense" min="0" max="500" value="150" required>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="antivirusCost">Antivirus License per User/Year (CAD)</label>
                     <input type="number" id="antivirusCost" min="0" max="200" value="45" required>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="avgSalary">Average Salary per Employee (CAD/year)</label>
                     <input type="number" id="avgSalary" min="20000" max="500000" value="75000" required>
-                    <div class="calc-cost-examples">
+                    <div class="rpcalc-cost-examples">
                         <small>Used to value the ~100 min/month each employee reclaims on Mac (Forrester, 2026)</small>
                     </div>
                 </div>
             </div>
 
             <div style="text-align: center;">
-                <button class="calc-calculate-btn" onclick="calculateTCO()">
+                <button class="rpcalc-calculate-btn" onclick="calculateTCO()">
                     Calculate Mac vs PC Savings
                 </button>
             </div>
 
-            <div id="results" class="calc-results-container">
-                <div class="calc-savings-summary">
-                    <div class="calc-savings-amount" id="totalSavings">$0</div>
-                    <div class="calc-savings-subtitle">Total 3-Year Savings with Mac</div>
-                    <div class="calc-savings-per-device" id="perDeviceSavings">$0 savings per device</div>
+            <div id="results" class="rpcalc-results-container">
+                <div class="rpcalc-savings-summary">
+                    <div class="rpcalc-savings-amount" id="totalSavings">$0</div>
+                    <div class="rpcalc-savings-subtitle">Total 3-Year Savings with Mac</div>
+                    <div class="rpcalc-savings-per-device" id="perDeviceSavings">$0 savings per device</div>
                 </div>
 
-                <div class="calc-break-even" id="breakEven">
+                <div class="rpcalc-break-even" id="breakEven">
                     <h3>Break-Even Point</h3>
                     <p id="breakEvenText">Your Mac investment pays for itself in X months</p>
                 </div>
 
-                <div class="calc-break-even" id="productivityValue">
+                <div class="rpcalc-break-even" id="productivityValue">
                     <h3>Bonus: Value of Reclaimed Productive Time</h3>
                     <p id="productivityText"></p>
                     <p id="productivityNote" style="font-size: 0.85rem; opacity: 0.85; margin-top: 0.5rem;">
@@ -104,133 +109,133 @@ The permalink must not change: this URL carries all the accumulated search equit
                     </p>
                 </div>
 
-                <div class="calc-comparison-grid">
-                    <div class="calc-cost-breakdown calc-pc">
+                <div class="rpcalc-comparison-grid">
+                    <div class="rpcalc-cost-breakdown rpcalc-pc">
                         <h3>Current PC Setup (3 Years)</h3>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Hardware Cost:</span>
                             <span id="pcHardware">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Windows Licenses:</span>
                             <span id="pcWindows">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Antivirus Licenses:</span>
                             <span id="pcAntivirus">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>IT Support (3 years):</span>
                             <span id="pcSupport">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Total PC Cost:</span>
                             <span id="pcTotal">$0</span>
                         </div>
                     </div>
 
-                    <div class="calc-cost-breakdown calc-mac">
+                    <div class="rpcalc-cost-breakdown rpcalc-mac">
                         <h3>Mac Setup (3 Years)</h3>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Hardware Cost:</span>
                             <span id="macHardware">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>macOS (Included):</span>
                             <span>$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Antivirus (Built-in):</span>
                             <span>$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>IT Support (3 years):</span>
                             <span id="macSupport">$0</span>
                         </div>
-                        <div class="calc-cost-item">
+                        <div class="rpcalc-cost-item">
                             <span>Total Mac Cost:</span>
                             <span id="macTotal">$0</span>
                         </div>
                     </div>
                 </div>
 
-                <div class="calc-ripeda-highlight">
+                <div class="rpcalc-ripeda-highlight">
                     <h3>Ready to Make the Switch?</h3>
                     <p>RIPEDA Consulting specializes in seamless Mac migrations for Calgary businesses. We'll handle everything from procurement to deployment, ensuring your team gets the most out of their new Apple devices from day one.</p>
                 </div>
             </div>
         </div>
 
-        <div class="calc-selling-points">
+        <div class="rpcalc-selling-points">
             <h3>Why Mac Wins for Business</h3>
-            <div class="calc-points-grid">
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+            <div class="rpcalc-points-grid">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Ready for Local AI Workloads</strong>
                         <span>Apple silicon runs AI and LLM tasks on-device — Forrester's 2026 study found teams adopt Mac specifically to run compute-intensive AI locally</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>55% Fewer IT Tickets</strong>
                         <span>Mac users create significantly fewer support requests, reducing IT workload</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>25% Lower Resolution Costs</strong>
                         <span>Mac issues are easier and faster to resolve when they do occur</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Built-in Enterprise Security</strong>
                         <span>No separate antivirus licensing needed - saves $45+ per user annually</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Higher Employee Productivity</strong>
                         <span>Studies show 5-10% productivity gains from fewer crashes and interruptions</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Longer Device Lifespan</strong>
                         <span>Macs typically last 4-5 years vs 3-4 years for PCs in business use</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Higher Resale Value</strong>
                         <span>Macs retain 60-70% value after 3 years vs 30-40% for comparable PCs</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>Simplified IT Management</strong>
                         <span>Apple Business Manager streamlines deployment and device management</span>
                     </div>
                 </div>
 
-                <div class="calc-point-item">
-                    <div class="calc-point-icon">•</div>
-                    <div class="calc-point-text">
+                <div class="rpcalc-point-item">
+                    <div class="rpcalc-point-icon">•</div>
+                    <div class="rpcalc-point-text">
                         <strong>IBM Saved $543 Per Mac</strong>
                         <span>Real enterprise data: IBM's 300,000+ Mac deployment showed measurable savings</span>
                     </div>
@@ -241,18 +246,18 @@ The permalink must not change: this URL carries all the accumulated search equit
 </div>
 
 <style>
-.calc-page * {
+.rpcalc-page * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-.calc-page {
+.rpcalc-page {
             font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
             background: #f8f9fa;
             min-height: 100vh;
             padding: 20px;
         }
-.calc-page .calc-calculator-container {
+.rpcalc-page .rpcalc-calculator-container {
             max-width: 1000px;
             margin: 0 auto;
             background: white;
@@ -260,51 +265,51 @@ The permalink must not change: this URL carries all the accumulated search equit
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
             overflow: hidden;
         }
-.calc-page .calc-header {
+.rpcalc-page .rpcalc-header {
             background: white;
             color: #2f2f41;
             padding: 40px;
             text-align: center;
             border-bottom: 1px solid #ddd;
         }
-.calc-page .calc-header h1 {
+.rpcalc-page .rpcalc-header h1 {
             font-size: 2.8em;
             margin-bottom: 15px;
             text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
         }
-.calc-page .calc-header p {
+.rpcalc-page .rpcalc-header p {
             font-size: 1.2em;
             opacity: 0.9;
             margin-bottom: 10px;
         }
-.calc-page .calc-subtitle {
+.rpcalc-page .rpcalc-subtitle {
             font-size: 1em;
             opacity: 0.8;
             font-weight: 300;
         }
-.calc-page .calc-form-container {
+.rpcalc-page .rpcalc-form-container {
             padding: 40px;
         }
-.calc-page .calc-form-grid {
+.rpcalc-page .rpcalc-form-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 30px;
             margin-bottom: 30px;
         }
-.calc-page .calc-form-group {
+.rpcalc-page .rpcalc-form-group {
             display: flex;
             flex-direction: column;
         }
-.calc-page .calc-form-group.calc-full-width {
+.rpcalc-page .rpcalc-form-group.rpcalc-full-width {
             grid-column: 1 / -1;
         }
-.calc-page label {
+.rpcalc-page label {
             font-weight: 600;
             color: #333;
             margin-bottom: 8px;
             font-size: 1.1em;
         }
-.calc-page input, .calc-page select {
+.rpcalc-page input, .rpcalc-page select {
             padding: 15px;
             border: 1px solid #ddd;
             border-radius: 12px;
@@ -312,13 +317,13 @@ The permalink must not change: this URL carries all the accumulated search equit
             transition: all 0.3s ease;
             background-color: white;
         }
-.calc-page input:focus, .calc-page select:focus {
+.rpcalc-page input:focus, .rpcalc-page select:focus {
             outline: none;
             border-color: #4a7c95;
             background-color: white;
             box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
         }
-.calc-page .calc-calculate-btn {
+.rpcalc-page .rpcalc-calculate-btn {
             background: linear-gradient(135deg, #4a7c95, #6b9ab8);
             color: white;
             border: none;
@@ -330,15 +335,15 @@ The permalink must not change: this URL carries all the accumulated search equit
             transition: all 0.3s ease;
             box-shadow: 0 6px 25px rgba(74, 124, 149, 0.3);
         }
-.calc-page .calc-calculate-btn:hover {
+.rpcalc-page .rpcalc-calculate-btn:hover {
             transform: translateY(-3px);
             box-shadow: 0 10px 35px rgba(74, 124, 149, 0.4);
         }
-.calc-page .calc-results-container {
+.rpcalc-page .rpcalc-results-container {
             margin-top: 30px;
             display: none;
         }
-.calc-page .calc-savings-summary {
+.rpcalc-page .rpcalc-savings-summary {
             background: linear-gradient(135deg, #4a7c95, #4282ae);
             color: white;
             padding: 40px;
@@ -347,57 +352,57 @@ The permalink must not change: this URL carries all the accumulated search equit
             margin-bottom: 30px;
             box-shadow: 0 10px 30px rgba(74, 124, 149, 0.3);
         }
-.calc-page .calc-savings-amount {
+.rpcalc-page .rpcalc-savings-amount {
             font-size: 3.5em;
             font-weight: bold;
             margin-bottom: 10px;
             text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
         }
-.calc-page .calc-savings-subtitle {
+.rpcalc-page .rpcalc-savings-subtitle {
             font-size: 1.3em;
             opacity: 0.9;
             margin-bottom: 5px;
         }
-.calc-page .calc-savings-per-device {
+.rpcalc-page .rpcalc-savings-per-device {
             font-size: 1.1em;
             opacity: 0.8;
         }
-.calc-page .calc-comparison-grid {
+.rpcalc-page .rpcalc-comparison-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 25px;
             margin-bottom: 30px;
         }
-.calc-page .calc-cost-breakdown {
+.rpcalc-page .rpcalc-cost-breakdown {
             background: white;
             padding: 30px;
             border-radius: 15px;
             box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
         }
-.calc-page .calc-cost-breakdown.calc-mac {
+.rpcalc-page .rpcalc-cost-breakdown.rpcalc-mac {
             border-left: 3px solid #4a7c95;
         }
-.calc-page .calc-cost-breakdown.calc-pc {
+.rpcalc-page .rpcalc-cost-breakdown.rpcalc-pc {
             border-left: 3px solid #6b9ab8;
         }
-.calc-page .calc-cost-breakdown h3 {
+.rpcalc-page .rpcalc-cost-breakdown h3 {
             font-size: 1.5em;
             margin-bottom: 20px;
             color: #333;
         }
-.calc-page .calc-cost-item {
+.rpcalc-page .rpcalc-cost-item {
             display: flex;
             justify-content: space-between;
             padding: 10px 0;
             border-bottom: 1px solid #f0f0f0;
         }
-.calc-page .calc-cost-item:last-child {
+.rpcalc-page .rpcalc-cost-item:last-child {
             border-bottom: none;
             font-weight: bold;
             font-size: 1.1em;
             color: #333;
         }
-.calc-page .calc-break-even {
+.rpcalc-page .rpcalc-break-even {
             background: linear-gradient(135deg, #6b9ab8, #4a7c95);
             color: white;
             padding: 25px;
@@ -405,28 +410,28 @@ The permalink must not change: this URL carries all the accumulated search equit
             text-align: center;
             margin-bottom: 30px;
         }
-.calc-page .calc-break-even h3 {
+.rpcalc-page .rpcalc-break-even h3 {
             font-size: 1.5em;
             margin-bottom: 10px;
         }
-.calc-page .calc-selling-points {
+.rpcalc-page .rpcalc-selling-points {
             background: #f8f9fa;
             padding: 40px;
             border-radius: 15px;
             margin-top: 30px;
         }
-.calc-page .calc-selling-points h3 {
+.rpcalc-page .rpcalc-selling-points h3 {
             color: #333;
             font-size: 1.8em;
             margin-bottom: 25px;
             text-align: center;
         }
-.calc-page .calc-points-grid {
+.rpcalc-page .rpcalc-points-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 20px;
         }
-.calc-page .calc-point-item {
+.rpcalc-page .rpcalc-point-item {
             display: flex;
             align-items: flex-start;
             padding: 20px;
@@ -436,33 +441,33 @@ The permalink must not change: this URL carries all the accumulated search equit
             transition: transform 0.2s ease;
             border-left: 3px solid #4a7c95;
         }
-.calc-page .calc-point-item:hover {
+.rpcalc-page .rpcalc-point-item:hover {
             transform: translateY(-2px);
         }
-.calc-page .calc-point-icon {
+.rpcalc-page .rpcalc-point-icon {
             font-size: 1.5em;
             margin-right: 15px;
             color: #4a7c95;
         }
-.calc-page .calc-point-text {
+.rpcalc-page .rpcalc-point-text {
             flex: 1;
         }
-.calc-page .calc-point-text strong {
+.rpcalc-page .rpcalc-point-text strong {
             color: #333;
             display: block;
             margin-bottom: 5px;
         }
-.calc-page .calc-point-text span {
+.rpcalc-page .rpcalc-point-text span {
             color: #666;
             font-size: 0.95em;
         }
-.calc-page .calc-cost-examples {
+.rpcalc-page .rpcalc-cost-examples {
             margin-top: 5px;
             font-size: 0.9em;
             color: #666;
             font-style: italic;
         }
-.calc-page .calc-ripeda-highlight {
+.rpcalc-page .rpcalc-ripeda-highlight {
             background: linear-gradient(135deg, #4a7c95, #6b9ab8);
             color: white;
             padding: 30px;
@@ -470,24 +475,24 @@ The permalink must not change: this URL carries all the accumulated search equit
             margin-top: 30px;
             text-align: center;
         }
-.calc-page .calc-ripeda-highlight h3 {
+.rpcalc-page .rpcalc-ripeda-highlight h3 {
             color: white;
             margin-bottom: 15px;
         }
 @media (max-width: 768px) {
-.calc-page .calc-form-grid, .calc-page .calc-comparison-grid, .calc-page .calc-points-grid {
+.rpcalc-page .rpcalc-form-grid, .rpcalc-page .rpcalc-comparison-grid, .rpcalc-page .rpcalc-points-grid {
                 grid-template-columns: 1fr;
             }
-.calc-page .calc-header h1 {
+.rpcalc-page .rpcalc-header h1 {
                 font-size: 2.2em;
             }
-.calc-page .calc-savings-amount {
+.rpcalc-page .rpcalc-savings-amount {
                 font-size: 2.5em;
             }
 }
 
 /* Layout integration overrides (added during conversion) */
-.calc-page { min-height: 0; padding: 40px 20px; }
+.rpcalc-page { min-height: 0; padding: 40px 20px; }
 </style>
 
 <script>

--- a/calculators/msp_cost_calculator.html
+++ b/calculators/msp_cost_calculator.html
@@ -16,26 +16,31 @@ to 2026-07-29, 44% of the site total). See Planning/SEO_BASELINE_pre-relaunch.md
 
 The original CSS used a global `*` reset plus bare `body`, `label` and `input`
 rules, and a `.header` class that collides with the site header. Every selector is
-therefore scoped under `.calc-page`. Do not remove that wrapper.
+therefore scoped under `.rpcalc-page`, and every calculator class carries an
+`rpcalc-` prefix. Do not remove the wrapper, and do not shorten the prefix to
+`calc-`: the site already defines .calc-header, .calc-title, .calc-icon,
+.calc-button and .calc-description in _sass/_calculators.scss for the
+calculator sidebar component. `rpcalc-` was verified against all 655 class
+names defined across _sass/ and assets/css/ and collides with none of them.
 
 The permalink must not change: this URL carries all the accumulated search equity.
 {%- endcomment -%}
 
-<div class="calc-page">
-<div class="calc-calculator-container">
-        <div class="calc-header">
+<div class="rpcalc-page">
+<div class="rpcalc-calculator-container">
+        <div class="rpcalc-header">
             <h1>IT Downtime Cost Calculator</h1>
             <p>Calculate the true cost of IT outages for Canadian businesses</p>
         </div>
 
-        <div class="calc-form-container">
-            <div class="calc-form-grid">
-                <div class="calc-form-group">
+        <div class="rpcalc-form-container">
+            <div class="rpcalc-form-grid">
+                <div class="rpcalc-form-group">
                     <label for="employees">Number of Affected Employees</label>
                     <input type="number" id="employees" min="1" max="1000" value="10" required>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="industry">Industry</label>
                     <select id="industry" required>
                         <option value="">Select your industry</option>
@@ -49,7 +54,7 @@ The permalink must not change: this URL carries all the accumulated search equit
                     </select>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="outageType">Type of IT Issue</label>
                     <select id="outageType" required>
                         <option value="">Select outage type</option>
@@ -61,13 +66,13 @@ The permalink must not change: this URL carries all the accumulated search equit
                     </select>
                 </div>
 
-                <div class="calc-form-group">
+                <div class="rpcalc-form-group">
                     <label for="duration">Outage Duration</label>
-                    <div class="calc-duration-container">
-                        <div class="calc-form-group">
+                    <div class="rpcalc-duration-container">
+                        <div class="rpcalc-form-group">
                             <input type="number" id="hours" min="0" max="72" value="2" placeholder="Hours">
                         </div>
-                        <div class="calc-form-group">
+                        <div class="rpcalc-form-group">
                             <input type="number" id="minutes" min="0" max="59" value="30" placeholder="Minutes">
                         </div>
                     </div>
@@ -75,36 +80,36 @@ The permalink must not change: this URL carries all the accumulated search equit
             </div>
 
             <div style="text-align: center;">
-                <button class="calc-calculate-btn" onclick="calculateCost()">
+                <button class="rpcalc-calculate-btn" onclick="calculateCost()">
                     Calculate IT Downtime Cost
                 </button>
             </div>
 
-            <div id="result" class="calc-result-container">
-                <div class="calc-result-amount" id="totalCost">$0</div>
+            <div id="result" class="rpcalc-result-container">
+                <div class="rpcalc-result-amount" id="totalCost">$0</div>
                 <p>Estimated cost of this IT outage</p>
                 
-                <div class="calc-result-breakdown">
+                <div class="rpcalc-result-breakdown">
                     <h4 style="margin-bottom: 15px;">Cost Breakdown:</h4>
-                    <div class="calc-breakdown-item">
+                    <div class="rpcalc-breakdown-item">
                         <span>Affected Employees:</span>
                         <span id="empCount">-</span>
                     </div>
-                    <div class="calc-breakdown-item">
+                    <div class="rpcalc-breakdown-item">
                         <span>Hourly Rate (Industry Avg):</span>
                         <span id="hourlyRate">-</span>
                     </div>
-                    <div class="calc-breakdown-item">
+                    <div class="rpcalc-breakdown-item">
                         <span>Outage Duration:</span>
                         <span id="outageTime">-</span>
                     </div>
-                    <div class="calc-breakdown-item">
+                    <div class="rpcalc-breakdown-item">
                         <span>Impact Multiplier:</span>
                         <span id="impactMultiplier">-</span>
                     </div>
                 </div>
 
-                <div class="calc-msp-cta">
+                <div class="rpcalc-msp-cta">
                     <h3>Prevent These Costly Outages</h3>
                     <p>RIPEDA's Managed Service Provider solutions can help prevent 80-90% of these IT issues through proactive monitoring, maintenance, and rapid response times.</p>
                 </div>
@@ -114,18 +119,18 @@ The permalink must not change: this URL carries all the accumulated search equit
 </div>
 
 <style>
-.calc-page * {
+.rpcalc-page * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-.calc-page {
+.rpcalc-page {
             font-family: -apple-system, "Helvetica Neue", sans-serif, serif, "Papyrus";
             background: #f8f9fa;
             min-height: 100vh;
             padding: 20px;
         }
-.calc-page .calc-calculator-container {
+.rpcalc-page .rpcalc-calculator-container {
             max-width: 800px;
             margin: 0 auto;
             background: white;
@@ -133,45 +138,45 @@ The permalink must not change: this URL carries all the accumulated search equit
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
             overflow: hidden;
         }
-.calc-page .calc-header {
+.rpcalc-page .rpcalc-header {
             background: white;
             color: #2f2f41;
             padding: 30px;
             text-align: center;
             border-bottom: 1px solid #ddd;
         }
-.calc-page .calc-header h1 {
+.rpcalc-page .rpcalc-header h1 {
             font-size: 2.5em;
             margin-bottom: 10px;
             text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
         }
-.calc-page .calc-header p {
+.rpcalc-page .rpcalc-header p {
             font-size: 1.1em;
             opacity: 0.9;
         }
-.calc-page .calc-form-container {
+.rpcalc-page .rpcalc-form-container {
             padding: 40px;
         }
-.calc-page .calc-form-grid {
+.rpcalc-page .rpcalc-form-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 30px;
             margin-bottom: 30px;
         }
-.calc-page .calc-form-group {
+.rpcalc-page .rpcalc-form-group {
             display: flex;
             flex-direction: column;
         }
-.calc-page .calc-form-group.calc-full-width {
+.rpcalc-page .rpcalc-form-group.rpcalc-full-width {
             grid-column: 1 / -1;
         }
-.calc-page label {
+.rpcalc-page label {
             font-weight: 600;
             color: #333;
             margin-bottom: 8px;
             font-size: 1.1em;
         }
-.calc-page input, .calc-page select {
+.rpcalc-page input, .rpcalc-page select {
             padding: 15px;
             border: 1px solid #ddd;
             border-radius: 10px;
@@ -179,21 +184,21 @@ The permalink must not change: this URL carries all the accumulated search equit
             transition: all 0.3s ease;
             background-color: white;
         }
-.calc-page input:focus, .calc-page select:focus {
+.rpcalc-page input:focus, .rpcalc-page select:focus {
             outline: none;
             border-color: #4a7c95;
             background-color: white;
             box-shadow: 0 0 0 3px rgba(74, 124, 149, 0.1);
         }
-.calc-page .calc-duration-container {
+.rpcalc-page .rpcalc-duration-container {
             display: flex;
             gap: 15px;
             align-items: end;
         }
-.calc-page .calc-duration-container .calc-form-group {
+.rpcalc-page .rpcalc-duration-container .rpcalc-form-group {
             flex: 1;
         }
-.calc-page .calc-calculate-btn {
+.rpcalc-page .rpcalc-calculate-btn {
             background: linear-gradient(135deg, #4a7c95, #6b9ab8);
             color: white;
             border: none;
@@ -205,11 +210,11 @@ The permalink must not change: this URL carries all the accumulated search equit
             transition: all 0.3s ease;
             box-shadow: 0 4px 20px rgba(74, 124, 149, 0.3);
         }
-.calc-page .calc-calculate-btn:hover {
+.rpcalc-page .rpcalc-calculate-btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 30px rgba(74, 124, 149, 0.4);
         }
-.calc-page .calc-result-container {
+.rpcalc-page .rpcalc-result-container {
             margin-top: 30px;
             padding: 30px;
             background: linear-gradient(135deg, #4a7c95, #4282ae);
@@ -218,27 +223,27 @@ The permalink must not change: this URL carries all the accumulated search equit
             text-align: center;
             display: none;
         }
-.calc-page .calc-result-amount {
+.rpcalc-page .rpcalc-result-amount {
             font-size: 3em;
             font-weight: bold;
             margin-bottom: 10px;
             text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
         }
-.calc-page .calc-result-breakdown {
+.rpcalc-page .rpcalc-result-breakdown {
             background: rgba(255, 255, 255, 0.1);
             padding: 20px;
             border-radius: 10px;
             margin-top: 20px;
             text-align: left;
         }
-.calc-page .calc-breakdown-item {
+.rpcalc-page .rpcalc-breakdown-item {
             display: flex;
             justify-content: space-between;
             margin-bottom: 8px;
             padding: 5px 0;
             border-bottom: 1px solid rgba(255, 255, 255, 0.2);
         }
-.calc-page .calc-msp-cta {
+.rpcalc-page .rpcalc-msp-cta {
             background: linear-gradient(135deg, #6b9ab8, #4a7c95);
             padding: 25px;
             margin-top: 20px;
@@ -246,26 +251,26 @@ The permalink must not change: this URL carries all the accumulated search equit
             text-align: center;
             color: white;
         }
-.calc-page .calc-msp-cta h3 {
+.rpcalc-page .rpcalc-msp-cta h3 {
             color: white;
             margin-bottom: 10px;
         }
 @media (max-width: 768px) {
-.calc-page .calc-form-grid {
+.rpcalc-page .rpcalc-form-grid {
                 grid-template-columns: 1fr;
                 gap: 20px;
             }
-.calc-page .calc-duration-container {
+.rpcalc-page .rpcalc-duration-container {
                 flex-direction: column;
                 align-items: stretch;
             }
-.calc-page .calc-header h1 {
+.rpcalc-page .rpcalc-header h1 {
                 font-size: 2em;
             }
 }
 
 /* Layout integration overrides (added during conversion) */
-.calc-page { min-height: 0; padding: 40px 20px; }
+.rpcalc-page { min-height: 0; padding: 40px 20px; }
 </style>
 
 <script>


### PR DESCRIPTION
Third pass. The previous commit namespaced the calculator classes with a `calc-` prefix to stop them colliding with site styles. That prefix was already taken.

_sass/_calculators.scss defines .calc-header, .calc-title, .calc-icon, .calc-button and .calc-description for the calculator sidebar component (_includes/calculator-sidebar.html). So .calc-header collided immediately, and the site's flex layout for the sidebar header kept applying to the calculator's own header - which is why the title, tagline and subtitle continued rendering side by side instead of stacked. The less common names, like .calc-form-grid, had no counterpart and did come out correct, which is why the form grid was fixed while the header was not.

The mistake was choosing a namespace without checking it was free. This commit checks properly:

- Every class in both calculators renamed from calc- to rpcalc-, in the CSS selectors and the markup class attributes together. 27 classes in the Mac calculator, 14 in the downtime calculator.
- The rpcalc- prefix was verified against all 655 class names defined across _sass/ and assets/css/. Zero collisions.
- Both files re-checked afterwards: no class outside the rpcalc- namespace, and no class intersecting the site's class list.
- The regex targeted class tokens only, so the CSS calc() function was never at risk.
- .rpcalc-header intentionally declares no `display`, so it falls back to block and its children stack, which is the original behaviour.
- Element IDs untouched again; both scripts work entirely through getElementById.
- The in-file comment now records why the prefix must not be shortened back to calc-, so this does not get reintroduced.

Permalinks unchanged.

NOT BUILT LOCALLY - no Ruby toolchain in this environment. After deploy the calculator header should be centred with the title, tagline and subtitle stacked vertically, and the form grid should remain two even columns filling the card.