### PR TITLE
Post-launch SEO cleanup: hero + contact layout, breadcrumbs, 2011 fou…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ permalink: pretty
 title: 'RIPEDA Consulting'
 
 # Enhanced Site metadata for SEO
-description: "Calgary's Apple Technical Partners. Over 13 years managing Apple devices for businesses, education, and enterprises."
+description: "Calgary's Apple Technical Partners. Managing Apple devices for businesses, education, and enterprises since 2011."
 url: "https://ripeda.com"
 locale: en_CA
 timezone: America/Edmonton
@@ -22,8 +22,8 @@ seo:
 # Business Information for Local SEO
 business:
   name: "RIPEDA Consulting"
-  founded: 2011
-  street_address: "300 - 1301 8 Street SW"
+  founded: "2011-12-03"
+  street_address: "1301 8 Street SW"
   city: "Calgary" 
   province: "Alberta"
   postal_code: "T2R 1B7"

--- a/_data/breadcrumbs.yml
+++ b/_data/breadcrumbs.yml
@@ -1,0 +1,12 @@
+# Friendly display names for URL path prefixes, used to build hierarchical
+# BreadcrumbList structured data in _layouts/default.html.
+#
+# Only list prefixes that resolve to a REAL landing page, so breadcrumb links
+# never 404. Keys are the URL path with NO leading/trailing slashes.
+# A page whose parent section is not listed here (e.g. /services/ and
+# /industries/, which have no landing page) simply renders as  Home > [page].
+# If a /services/ or /industries/ index is added later, add a line here.
+sections:
+  "resources": "Resources"
+  "resources/insights": "Insights"
+  "case-studies": "Case Studies"

--- a/_data/seo.yml
+++ b/_data/seo.yml
@@ -21,6 +21,6 @@
 cloudflare_analytics_token: "6922de1bcdd14d1e8f4d2ce601d18b9c"
 copyright_text: 'Copyright © RIPEDA Consulting Corporation. All rights reserved.'
 service_areas_text: 'Serving Alberta businesses in Calgary, Edmonton, Red Deer, Lethbridge, and surrounding areas with expert Apple device management, repair, and infrastructure.'
-address: 'Suite 300 - 1301 8 Street SW, Calgary, AB T2R 1B7'
+address: '1301 8 Street SW, Calgary, AB T2R 1B7'
 google_maps_url: https://www.google.com/maps/place/1301+8+St+SW+%23300,+Calgary,+AB+T2R+1B7/@51.0407223,-114.0845371,17z
 apple_maps_url: http://maps.apple.com/?address=1301+8+St+SW+%23300,+Calgary,+AB+T2R+1B7

--- a/_includes/expand-years.html
+++ b/_includes/expand-years.html
@@ -9,6 +9,12 @@
   Renders as "14 years..." in 2026, "15 years..." in 2027, etc. No annual
   source-edit required.
 
+  NOTE ON THE BASE YEAR: RIPEDA was founded 3 December 2011, but the badge base
+  is 2012, not 2011. Plain year subtraction (current_year - base) with base 2012
+  yields the number of COMPLETED years for most of the year (14 in 2026), rolling
+  to 15 after the December anniversary. Using 2011 would over-count by one until
+  December. Do not "correct" 2012 to 2011.
+
   Usage from a layout:
     {%- capture badge_text -%}{%- include expand-years.html text=badge -%}{%- endcapture -%}
     {{ badge_text }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -195,29 +195,45 @@
   </script>
   {% endif %}
 
-  <!-- BreadcrumbList Schema -->
-  {% unless page.is_home %}
+  <!-- BreadcrumbList Schema (hierarchical, built from the URL path) -->
+  {% unless page.is_home %}{% if page.breadcrumb != false %}
+  {%- comment -%}
+  Walk the URL path: for each ancestor prefix that maps to a real landing page
+  in _data/breadcrumbs.yml, emit a crumb, then the current page last. Ancestors
+  with no landing page (e.g. /services/) are skipped so breadcrumb links never
+  404. Set `breadcrumb: false` in a page's front matter to suppress entirely.
+  {%- endcomment -%}
+  {%- assign _crumbs = "Home@@/" -%}
+  {%- assign _segs = page.url | split: "/" -%}
+  {%- assign _prefix = "" -%}
+  {%- for _seg in _segs -%}
+    {%- if _seg == "" -%}{%- continue -%}{%- endif -%}
+    {%- if _prefix == "" -%}{%- assign _prefix = _seg -%}{%- else -%}{%- assign _prefix = _prefix | append: "/" | append: _seg -%}{%- endif -%}
+    {%- assign _full = "/" | append: _prefix | append: "/" -%}
+    {%- if _full == page.url -%}{%- break -%}{%- endif -%}
+    {%- assign _name = site.data.breadcrumbs.sections[_prefix] -%}
+    {%- if _name -%}{%- assign _crumbs = _crumbs | append: "||" | append: _name | append: "@@" | append: _full -%}{%- endif -%}
+  {%- endfor -%}
+  {%- assign _crumbs = _crumbs | append: "||" | append: page.title | append: "@@" | append: page.url -%}
+  {%- assign _crumblist = _crumbs | split: "||" -%}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
+      {%- for _c in _crumblist -%}
+      {%- assign _p = _c | split: "@@" -%}
       {
         "@type": "ListItem",
-        "position": 1,
-        "name": "Home",
-        "item": "{{ site.url }}"
-      },
-      {
-        "@type": "ListItem",
-        "position": 2,
-        "name": "{{ page.title }}",
-        "item": "{{ page.url | absolute_url }}"
-      }
+        "position": {{ forloop.index }},
+        "name": {{ _p[0] | jsonify }},
+        "item": {{ _p[1] | absolute_url | jsonify }}
+      }{% unless forloop.last %},{% endunless %}
+      {%- endfor -%}
     ]
   }
   </script>
-  {% endunless %}
+  {% endif %}{% endunless %}
 
   <!-- Google Fonts CDN -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/_sass/pages/_page-home-2026.scss
+++ b/_sass/pages/_page-home-2026.scss
@@ -38,6 +38,15 @@ $success-green: #10b981;
     gap: 4rem;
     align-items: center;
 
+    // Pages whose hero has no .hero-visual (e.g. Resources, Team) would leave
+    // the second grid column empty, squeezing .hero-text to ~half width and
+    // wrapping the h1 early. Collapse to a single column when there is no
+    // visual. The homepage keeps its two-column grid because it has a
+    // .hero-visual. Requires :has() (supported in all current browsers).
+    &:not(:has(.hero-visual)) {
+      display: block;
+    }
+
     @media (max-width: 768px) {
       grid-template-columns: 1fr;
       gap: 3rem;
@@ -1027,6 +1036,14 @@ $success-green: #10b981;
 // Contact Section Specific
 .contact-section {
   background: #f8fafc;
+
+  // Top-align the two columns. The shared .content-section grid uses
+  // align-items: center; because the contact form column is much taller than
+  // the left text column, that centering strands the section header in the
+  // vertical middle of the section instead of at the top. Override to start.
+  .section-container {
+    align-items: start;
+  }
 
   .consultation-offer {
     h3 {

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ is_home: true
 <!-- Partner Trust Strip -->
 <section class="partner-strip-section">
   <div class="partner-strip-container">
-    <p class="partner-strip-tagline">Delivering Technology Solutions for Alberta Businesses since 2010</p>
+    <p class="partner-strip-tagline">Delivering Technology Solutions for Alberta Businesses since 2011</p>
     <div class="partner-strip-logos">
       <img src="{{ '/images/logo/AppleAuth.svg' | relative_url }}" alt="Apple Technical Partner, Authorized Repair, Authorized Reseller" class="partner-strip-logo apple-strip-logo">
       <img src="{{ '/images/logo/RUCKUS-Partner-2025_Partner-Levels-Certified.svg' | relative_url }}" alt="Ruckus Certified Partner" class="partner-strip-logo">

--- a/privacy.md
+++ b/privacy.md
@@ -25,7 +25,7 @@ RIPEDA is accountable for the personal information in our custody or control, in
 Our **Privacy Officer** is responsible for our compliance with this policy, and can answer questions about how your personal information is collected, used, disclosed or stored — including by our service providers.
 
 **Privacy Officer, RIPEDA Consulting Corporation**
-Suite 300 – 1301 8 Street SW, Calgary, AB T2R 1B7
+1301 8 Street SW, Calgary, AB T2R 1B7
 [info@ripeda.com](mailto:info@ripeda.com) · +1 (844) 474-7332
 
 ## 2. What we collect, and why


### PR DESCRIPTION
…nding, NAP

Post-launch SEO/consistency pass. All changes verified by reading the live source and simulating the Liquid where it could not be built in the sandbox.

Layout fixes (_sass/pages/_page-home-2026.scss)
- Hero left-shift on pages with no hero visual. The shared .hero-section grid expects .hero-text in column 1 and .hero-visual in column 2. Resources and Team have no visual, so column 2 sat empty and squeezed the heading to ~half width, wrapping the h1 early. Collapse .hero-content to one column when there is no .hero-visual (:not(:has(.hero-visual))). Homepage keeps two columns.
- Contact section header floating to the vertical middle. The shared .content-section grid uses align-items: center; because the contact form column is much taller than the left text column, the header was centred against the form instead of sitting at the top. Override the contact section to align-items: start.

Structured data (_layouts/default.html, _data/breadcrumbs.yml)
- BreadcrumbList was flat (Home > page) on every page. Now hierarchical, built from the URL path: for each ancestor prefix that maps to a real landing page in the new _data/breadcrumbs.yml, emit a crumb, then the current page last. Insights -> Home > Resources > Insights > Article; case studies -> Home > Case Studies > Study. Service/industry pages stay Home > page (no landing page exists, a crumb there would 404). breadcrumb: false suppresses the trail. (FAQPage on /faq/ and BlogPosting on the Insights posts were already present and complete - not touched.)

Founding year reconciled to 2011 (confirmed founded 3 December 2011) The site carried three inconsistent values: "since 2010" (homepage + meta description), foundingDate 2011 (schema), and prose/badges dividing by 2012.
- _config.yml description: durable "since 2011" (was "Over 13 years")
- index.html partner-strip tagline: "since 2011" (was "since 2010")
- _config.yml business.founded: exact "2011-12-03" (feeds LocalBusiness foundingDate; was bare 2011)
- Experience badges/counters keep base 2012 on purpose: plain year subtraction yields completed years for most of the year ("14 years" in 2026, rolling to 15 after the December anniversary). expand-years.html documents why not 2011.

NAP address - drop "Suite 300" to match the Google Business Profile
- _data/seo.yml footer address: suite removed
- _config.yml street_address (LocalBusiness schema): "300 - ..." -> "..."
- privacy.md Privacy Officer address: suite removed
- Map link URLs in seo.yml deliberately keep #300 so the pin stays precise.